### PR TITLE
fix brackets in model name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ bash_scripts/dependencies_2115/
 # paths to Models to test
 # change a lot between computers (abs paths) and inputs (contents)
 resources/models_to_test.txt
+resources/models_to_test.edn
 resources/models_to_test.sh
 resources/test_the_models.sh
 resources/rdfs_to_test.txt

--- a/java_CI_scripts/src/config.clj
+++ b/java_CI_scripts/src/config.clj
@@ -17,18 +17,21 @@
    :report          (fs/file (:summa-root ROOTS) "report.md")
    :bash-script     (fs/file (:resources-root ROOTS) "test_the_models.sh")
    :models-listed   (fs/file (:resources-root ROOTS) "models_to_test.txt")
+   :models-vector   (fs/file (:resources-root ROOTS) "models_to_test.edn")
    :rdfs-listed     (fs/file (:resources-root ROOTS) "rdfs_to_test.txt")
    :fiji-home       (fs/file (System/getProperty "user.home") "blank_fiji" "Fiji.app")})
 
 (def CONSTANTS "Constants that are not files"
-  {:fiji-flags            ["--headless" "--ij2" "--console" "--run"]
-   :fiji-executable       (str (fs/file (:fiji-home FILES)
-                                        (if (str/includes? (System/getProperty "os.name") "Windows")
-                                          "ImageJ-win64.exe" "ImageJ-linux64")))
-   :fiji-scripts-arg-name "folder"
-   :output-metrics-name   "output_metrics.edn"
-   :summary-name          "test_summary.yaml"
-   :mse-threshold         2.0})
+  {:fiji-flags             ["--headless" "--ij2" "--console" "--run"]
+   :fiji-executable        (str (fs/file (:fiji-home FILES)
+                                         (if (str/includes? (System/getProperty "os.name") "Windows")
+                                           "ImageJ-win64.exe" "ImageJ-linux64")))
+   :fiji-scripts-arg-name  "folder"
+   :output-metrics-name    "output_metrics.edn"
+   :summary-name           "test_summary.yaml"
+   :dij-args-filename      "dij_args.edn"
+   :mse-threshold          2.0
+   :special-headless-chars #{" " "_"}})
 
 (defn absolutize-nested
   "absolutize values of dictionary that are files"

--- a/java_CI_scripts/src/reproduce/communicate.clj
+++ b/java_CI_scripts/src/reproduce/communicate.clj
@@ -73,7 +73,11 @@
 
 (defn bracketize
   "Surround a string with [brackets] if it has special characters (spaces, underscores, ...)"
-  [s] (str "[" s "]"))
+  [s]
+  (let [list-contains-special? (map #(str/includes? s %) (:special-headless-chars CONSTANTS))]
+    ; idiom for applying OR to a list of booleans
+    (if (some identity list-contains-special?)
+      (str "[" s "]") s)))
 
 (defn dij-arg-str
   "Makes the DIJ argument as a string"

--- a/java_CI_scripts/test/reproduce/communicate_test.clj
+++ b/java_CI_scripts/test/reproduce/communicate_test.clj
@@ -42,11 +42,14 @@
                        :logging "Normal"}))))
 
 (deftest bracketize-test
-  (is (= "[abc]" (bracketize "abc"))))
+  (are [expected input] (= expected (bracketize input))
+                        "abc" "abc"
+                        "[with many spaces]" "with many spaces"
+                        "[with_underscores_]" "with_underscores_"))
 
 (deftest dij-arg-str-test
   (is (= (dij-arg-str (nth @model-records 1))
-         "model=[Cell Segmentation from Membrane Staining for Plant Tissues] format=Tensorflow preprocessing=[per_sample_scale_range.ijm] postprocessing=[binarize.ijm] axes=Y,X,Z,C tile=256,256,8,1 logging=Normal")))
+         "model=[Cell Segmentation from Membrane Staining for Plant Tissues] format=Tensorflow preprocessing=[per_sample_scale_range.ijm] postprocessing=binarize.ijm axes=Y,X,Z,C tile=256,256,8,1 logging=Normal")))
 
 (deftest get-name-from-url-test
   (is (= (get-name-from-url "https://zenodo.org/my-file.txt") "my-file.txt")))
@@ -83,7 +86,6 @@
     (testing "After test, delete existing file"
       (is (fs/delete-if-exists c-file))
       (is (c-file-not-in-dir? "." c-name)))))
-
 
 (deftest write-dij-model-test
   (let [model-folders (map #(get-in % [:paths :model-dir-path]) (rest @model-records))]

--- a/java_CI_scripts/test/reproduce/communicate_test.clj
+++ b/java_CI_scripts/test/reproduce/communicate_test.clj
@@ -1,5 +1,6 @@
 (ns reproduce.communicate-test
-  (:require [reproduce.communicate :refer :all]
+  (:require [config :refer [FILES]]
+            [reproduce.communicate :refer :all]
             [test-setup :refer [load-test-paths load-model-records model-records all-model-records]]
             [clojure.test :refer :all]
             [clojure.string :as str]
@@ -45,7 +46,7 @@
 
 (deftest dij-arg-str-test
   (is (= (dij-arg-str (nth @model-records 1))
-         "model=[Cell Segmentation from Membrane Staining for Plant Tissues] format=[Tensorflow] preprocessing=[per_sample_scale_range.ijm] postprocessing=[binarize.ijm] axes=Y,X,Z,C tile=256,256,8,1 logging=Normal")))
+         "model=[Cell Segmentation from Membrane Staining for Plant Tissues] format=Tensorflow preprocessing=[per_sample_scale_range.ijm] postprocessing=[binarize.ijm] axes=Y,X,Z,C tile=256,256,8,1 logging=Normal")))
 
 (deftest get-name-from-url-test
   (is (= (get-name-from-url "https://zenodo.org/my-file.txt") "my-file.txt")))
@@ -65,7 +66,7 @@
 
 (deftest write-comm-file-test
   (let [dij-models (map build-dij-model (rest @model-records))
-        c-name (fs/file-name comm-file)
+        c-name (fs/file-name (:models-vector FILES))
         c-file (fs/file "." c-name)
         c-file-not-in-dir? (fn [root name]
                          (empty? (filter #(= % name) (map fs/file-name (fs/list-dir root)))))]

--- a/java_CI_scripts/todos.md
+++ b/java_CI_scripts/todos.md
@@ -1,6 +1,6 @@
 # To-Do's
 ## Use constants from config
-- [ ] refactor `reproduce.communicate.clj`
+- [x] refactor `reproduce.communicate.clj`
 - [ ] read serialized config in `test_1_with_deepimagej.clj`
 
 ## Refactor utils


### PR DESCRIPTION
Fix problem in deepimagej headless where brackets surrounding strings names are not always needed.